### PR TITLE
Fix broken build jobs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       
       - name: Test executable exists
         run: |
-          if (Test-Path "dist/BookTranslator.exe") {
+          if (Test-Path "dist/BookTranslator/BookTranslator.exe") {
             Write-Host "✅ Executable built successfully"
           } else {
             Write-Error "❌ Executable not found"
@@ -149,7 +149,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: BookTranslator-Windows
-          path: dist/BookTranslator.exe
+          path: dist/BookTranslator/BookTranslator.exe
           retention-days: 30
 
   build-docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run -p 5001:5001 -v ./translations:/app/translations book-translator
 
 # Stage 1: Build stage
-FROM python:3.12-slim as builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
@@ -23,16 +23,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir \
-    Flask==3.1.2 \
-    Flask-CORS==6.0.2 \
-    requests==2.32.3 \
-    psutil==5.9.8 \
-    Werkzeug==3.1.3 \
-    gunicorn==23.0.0
+    pip install --no-cache-dir -r requirements.txt gunicorn==23.0.0
 
 # Stage 2: Production stage
-FROM python:3.12-slim as production
+FROM python:3.12-slim AS production
 
 # Create non-root user for security
 RUN groupadd -r translator && useradd -r -g translator translator
@@ -44,7 +38,8 @@ COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy application code
-COPY translator.py config.py ./
+COPY run.py ./
+COPY book_translator/ ./book_translator/
 COPY static/ ./static/
 
 # Create necessary directories with correct permissions
@@ -69,4 +64,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import requests; requests.get('http://localhost:5001/health', timeout=5)" || exit 1
 
 # Run with gunicorn for production
-CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--threads", "4", "--timeout", "300", "translator:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--threads", "4", "--timeout", "300", "--factory", "book_translator.app:create_app"]


### PR DESCRIPTION
## Summary
- fix Docker build for the modular project layout
- fix Windows executable artifact path in CI
- keep the existing build workflow aligned with the current PyInstaller spec

## Verification
- `pytest -q` (`107 passed`)
- `python3.11 -m py_compile run.py book_translator/app.py`
- inspected failing GitHub Actions logs for `Build Docker Image` and `Build Executable` on push run `23376889176`