### PR TITLE
Move CI workflow actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       
@@ -52,10 +52,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       
@@ -73,7 +73,7 @@ jobs:
           pytest tests/ -v --cov=book_translator --cov-report=xml --cov-report=term-missing
       
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         with:
           files: ./coverage.xml
@@ -85,10 +85,10 @@ jobs:
     needs: lint
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       
@@ -104,7 +104,7 @@ jobs:
         run: safety check -r requirements.txt --output json > safety-report.json || true
       
       - name: Upload security reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: security-reports
           path: |
@@ -118,10 +118,10 @@ jobs:
     if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       
@@ -146,7 +146,7 @@ jobs:
         shell: pwsh
       
       - name: Upload executable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: BookTranslator-Windows
           path: dist/BookTranslator/BookTranslator.exe
@@ -159,7 +159,7 @@ jobs:
     if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -180,17 +180,15 @@ jobs:
     if: github.event_name == 'release'
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: BookTranslator-Windows
           path: artifacts/
       
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: artifacts/BookTranslator.exe
+        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/BookTranslator.exe --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# Book Translator
+<p align="center">
+  <img src="app_icon.ico" alt="Book Translator logo" width="120">
+</p>
 
-Translate long-form text files through a local Ollama-powered desktop and web app.
+<h1 align="center">Book Translator</h1>
+
+<p align="center">
+  Translate long-form text files through a local Ollama-powered desktop and web app.
+</p>
+
+<p align="center">
+  <a href="https://github.com/KazKozDev/book-translator/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/KazKozDev/book-translator/ci.yml?branch=main&label=CI" alt="CI status">
+  </a>
+  <a href="LICENSE">
+    <img src="https://img.shields.io/github/license/KazKozDev/book-translator" alt="MIT license">
+  </a>
+  <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/Ollama-local%20models-111111" alt="Ollama local models">
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Web-2ea44f" alt="Platforms">
+</p>
 
 Book Translator provides a two-stage workflow for translating books and large documents: first it generates a draft translation, then it runs a second pass to improve fluency, consistency, and style. The project targets users who want a local-first interface, progress tracking, saved history, and downloadable output without building a custom prompt pipeline around Ollama.
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow steps to Node 24-compatible action versions
- replace the release upload action with `gh release upload` because current `softprops/action-gh-release` tags still run on Node 20
- keep build, test, and release behavior aligned with the existing workflow

## Verification
- `pytest -q` (`107 passed`)
- `python3.11 -m py_compile run.py book_translator/app.py`
- verified official action metadata for Node 24 support before updating versions